### PR TITLE
Feat: add .babelrc file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["next/babel"],
+    "plugins": []
+  }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/babel","next/core-web-vitals"]
 }


### PR DESCRIPTION
# Create config file to remove error

### error received
 ```
error : Parsing error: Cannot find module 'next/babel' Require stack: 
- /Users/chantalgoethals/Dropbox/turing/M5/react-fit-lit/fitlit/node_modules/next/dist/compiled/babel/bundle.js - 
- /Users/chantalgoethals/Dropbox/turing/M5/react-fit-lit/fitlit/node_modules/next/dist/compiled/babel/eslint-parser.js 
- /Users/chantalgoethals/Dropbox/turing/M5/react-fit-lit/fitlit/node_modules/eslint-config-next/parser.js 
- /Users/chantalgoethals/Dropbox/turing/M5/react-fit-lit/fitlit/node_modules/@eslint/eslintrc/dist/eslintrc.cjseslint
```

<img width="400" alt="Screenshot 2023-03-29 at 11 53 04 AM" src="https://user-images.githubusercontent.com/102189342/228627051-ad7ac074-2091-46d1-bfe3-4112136899f6.png">
<img width="400" alt="Screenshot 2023-03-29 at 11 53 09 AM" src="https://user-images.githubusercontent.com/102189342/228627031-75db5278-0df5-4409-be73-b70baf230e97.png">



- Resolved issue with: 
  -  adding `.babelrc` 
  - adjusted `.eslintrc.json`



Sources: 
[Stackoverflow - Parsing error](https://stackoverflow.com/questions/68163385/parsing-error-cannot-find-module-next-babel)

