### PR TITLE
Render sleep data / Export helpers

### DIFF
--- a/src/pages/_hydration.js
+++ b/src/pages/_hydration.js
@@ -1,74 +1,29 @@
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import * as dayjs from "dayjs";
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { getDaysOfWeek } from "../../utils/helpers.utils";
 
 const Hydration = () => {
-
-const [findHydrationAmt, setFindHydrationAmt] = useState("")
-
   const user = useSelector((state) => state.user);
   const hydrationData = useSelector((state) => state.hydration);
+  const [selectedDate, setselectedDate] = useState("");
   const today = dayjs().format("YYYY/MM/DD");
-
 
   const findDayIntake = (date) => {
     const userHydrationData = hydrationData.filter(
       (hydro) => hydro.userID === user.id
     );
     const intake = userHydrationData.find((hydro) => hydro.date === date);
-    return `${intake?.numOunces}oz`;
+    return !intake ? "none" : `${intake.numOunces}oz`;
   };
 
-  function getPreviousDaysOfWeekFromDate() {
-    const today = new Date();
-    const daysOfWeek = [
-      "Sunday",
-      "Monday",
-      "Tuesday",
-      "Wednesday",
-      "Thursday",
-      "Friday",
-      "Saturday",
-    ];
-    const dayOfWeekIndex = today.getDay();
-    const mondayDate = new Date(today);
-    mondayDate.setDate(today.getDate() - dayOfWeekIndex + 1); // Set date to the nearest Monday
-    const previousDaysOfWeek = [];
-    for (let i = 1; i < dayOfWeekIndex; i++) {
-      const previousDay = new Date(mondayDate);
-      previousDay.setDate(mondayDate.getDate() + i - 1);
-      const formattedDate =
-        previousDay.getFullYear() +
-        "/" +
-        (previousDay.getMonth() + 1).toString().padStart(2, "0") +
-        "/" +
-        previousDay.getDate().toString().padStart(2, "0");
+  const daysOfWeek = getDaysOfWeek().map((day) => findDayIntake(day));
 
-      previousDaysOfWeek.push(formattedDate);
-    }
-    return previousDaysOfWeek;
-  }
-
-  const getAllData = () => {
-    const daysOfWeek = getPreviousDaysOfWeekFromDate();
-    daysOfWeek.push(today);
-    const data = daysOfWeek.map((day) => findDayIntake(day));
-    return data;
+  const handleChange = (e) => {
+    const day = dayjs(e).format("YYYY/MM/DD");
+    setselectedDate(findDayIntake(day));
   };
-  const weeksIntake = getAllData();
-  
-
-const handleChange = (e) => {
-
-  // console.log(e)
-  const today = dayjs(e).format("YYYY/MM/DD");
-console.log({today})
-setFindHydrationAmt(findDayIntake(today))
-}
-
-
-
 
   return (
     <div className="water-widget-container">
@@ -83,54 +38,30 @@ setFindHydrationAmt(findDayIntake(today))
         <div className="water-intake-font">
           <span>This week's intake: </span>
         </div>
-      <div className="lower-water-wrapper">
-        <div className="days-of-the-wk-grid">
-          <div className="dow m">M</div>
-          <div className="dow tu">Tu</div>
-          <div className="dow w">W</div>
-          <div className="dow th">Th</div>
-          <div className="dow f">F</div>
-          <div className="dow sa">Sa</div>
-          <div className="dow su">Su</div>
+        <div className="lower-water-wrapper">
+          <div className="days-of-the-wk-grid">
+            <div className="dow m">M</div>
+            <div className="dow tu">Tu</div>
+            <div className="dow w">W</div>
+            <div className="dow th">Th</div>
+            <div className="dow f">F</div>
+            <div className="dow sa">Sa</div>
+            <div className="dow su">Su</div>
 
-
-          <div className="h2o amt m"> 
-          {weeksIntake[0] || "-"}
+            <div className="h2o amt m">{daysOfWeek[0] || "-"}</div>
+            <div className="h2o amt tu">{daysOfWeek[1] || "-"}</div>
+            <div className="h2o amt w">{daysOfWeek[2] || "-"}</div>
+            <div className="h2o amt th">{daysOfWeek[3] || "-"}</div>
+            <div className="h2o amt f">{daysOfWeek[4] || "-"}</div>
+            <div className="h2o amt sa">{daysOfWeek[5] || "-"}</div>
+            <div className="h2o amt su">{daysOfWeek[6] || "-"}</div>
           </div>
-          <div className="h2o amt tu">
-          {weeksIntake[1] || "-"}
-
-          </div>
-          <div className="h2o amt w">
-          {weeksIntake[2]|| "-" }
-
-          </div>
-          <div className="h2o amt th">
-          {weeksIntake[3] || "-"}
-
-          </div>
-          <div className="h2o amt f">
-          {weeksIntake[4]|| "-" }
-
-          </div>
-          <div className="h2o amt sa">
-          {weeksIntake[5]|| "-" }
-
-          </div>
-          <div className="h2o amt su">
-          {weeksIntake[6]|| "-" } 
-
-          </div>
-
         </div>
-      </div>
-      <div className="find-oz-wrapper">
-        <DatePicker onChange={e => handleChange(e)}/>
-        <div className="found-oz-wrapper">
-          <p className="oz-drank"> 
-          {findHydrationAmt}
-          </p>
-        </div>
+        <div className="find-oz-wrapper">
+          <DatePicker onChange={(e) => handleChange(e)} />
+          <div className="found-oz-wrapper">
+            <p className="oz-drank">{selectedDate}</p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/_hydration.js
+++ b/src/pages/_hydration.js
@@ -9,6 +9,7 @@ const Hydration = () => {
   const hydrationData = useSelector((state) => state.hydration);
   const [selectedDate, setselectedDate] = useState("");
   const today = dayjs().format("YYYY/MM/DD");
+  const daysAbreviated = ["Su", "M", "Tu", "W", "Th", "F", "Sa"];
 
   const findDayIntake = (date) => {
     const userHydrationData = hydrationData.filter(
@@ -25,6 +26,14 @@ const Hydration = () => {
     setselectedDate(findDayIntake(day));
   };
 
+  const days = daysAbreviated.map((day) => (
+    <div className={`dow ${day}`}>{day}</div>
+  ));
+
+  const dayStats = daysAbreviated.map((day, i) => (
+    <div className={`h2o amt ${day}`}>{daysOfWeek[i] || "-"}</div>
+  ));
+
   return (
     <div className="water-widget-container">
       <div className="water-widget-hero">
@@ -40,21 +49,8 @@ const Hydration = () => {
         </div>
         <div className="lower-water-wrapper">
           <div className="days-of-the-wk-grid">
-            <div className="dow m">M</div>
-            <div className="dow tu">Tu</div>
-            <div className="dow w">W</div>
-            <div className="dow th">Th</div>
-            <div className="dow f">F</div>
-            <div className="dow sa">Sa</div>
-            <div className="dow su">Su</div>
-
-            <div className="h2o amt m">{daysOfWeek[0] || "-"}</div>
-            <div className="h2o amt tu">{daysOfWeek[1] || "-"}</div>
-            <div className="h2o amt w">{daysOfWeek[2] || "-"}</div>
-            <div className="h2o amt th">{daysOfWeek[3] || "-"}</div>
-            <div className="h2o amt f">{daysOfWeek[4] || "-"}</div>
-            <div className="h2o amt sa">{daysOfWeek[5] || "-"}</div>
-            <div className="h2o amt su">{daysOfWeek[6] || "-"}</div>
+            {days}
+            {dayStats}
           </div>
         </div>
         <div className="find-oz-wrapper">

--- a/src/pages/_sleep.js
+++ b/src/pages/_sleep.js
@@ -9,6 +9,7 @@ const Sleep = () => {
   const [selectedDate, setSelectedDate] = useState("");
   const sleepData = useSelector((state) => state.sleep);
   const userSleepData = sleepData.filter((sleep) => sleep.userID === user.id);
+  const daysAbreviated = ["Su", "M", "Tu", "W", "Th", "F", "Sa"];
 
   const findDailySleepData = (date) => {
     const userSleepData = sleepData.filter((sleep) => sleep.userID === user.id);
@@ -26,6 +27,14 @@ const Sleep = () => {
     const today = dayjs(e).format("YYYY/MM/DD");
     setSelectedDate(findDailySleepData(today));
   };
+
+  const days = daysAbreviated.map((day) => (
+    <div className={`dow ${day}`}>{day}</div>
+  ));
+  
+  const dayStats = daysAbreviated.map((day, i) => (
+    <div className={`h2o amt ${day}`}>{daysOfWeek[i] || "-"}</div>
+  ));
 
   return (
     <div>
@@ -46,21 +55,8 @@ const Sleep = () => {
       </div>
       <div className="lower-water-wrapper">
         <div className="days-of-the-wk-grid">
-          <div className="dow m">M</div>
-          <div className="dow tu">Tu</div>
-          <div className="dow w">W</div>
-          <div className="dow th">Th</div>
-          <div className="dow f">F</div>
-          <div className="dow sa">Sa</div>
-          <div className="dow su">Su</div>
-
-          <div className="h2o amt m">{daysOfWeek[0] || "-"}</div>
-          <div className="h2o amt tu">{daysOfWeek[1] || "-"}</div>
-          <div className="h2o amt w">{daysOfWeek[2] || "-"}</div>
-          <div className="h2o amt th">{daysOfWeek[3] || "-"}</div>
-          <div className="h2o amt f">{daysOfWeek[4] || "-"}</div>
-          <div className="h2o amt sa">{daysOfWeek[5] || "-"}</div>
-          <div className="h2o amt su">{daysOfWeek[6] || "-"}</div>
+          {days}
+          {dayStats}
         </div>
       </div>
     </div>

--- a/src/pages/_sleep.js
+++ b/src/pages/_sleep.js
@@ -1,0 +1,70 @@
+import { DatePicker } from "@mui/x-date-pickers";
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import * as dayjs from "dayjs";
+import { findAvg, getDaysOfWeek } from "../../utils/helpers.utils";
+
+const Sleep = () => {
+  const user = useSelector((state) => state.user);
+  const [selectedDate, setSelectedDate] = useState("");
+  const sleepData = useSelector((state) => state.sleep);
+  const userSleepData = sleepData.filter((sleep) => sleep.userID === user.id);
+
+  const findDailySleepData = (date) => {
+    const userSleepData = sleepData.filter((sleep) => sleep.userID === user.id);
+    const sleep = userSleepData.find((sleep) => sleep.date === date);
+    return sleep
+      ? `Hours: ${sleep.hoursSlept || "no data"} Quality: ${
+          sleep.sleepQuality || "no data"
+        }`
+      : "none";
+  };
+
+  const daysOfWeek = getDaysOfWeek().map((day) => findDailySleepData(day));
+
+  const handleChange = (e) => {
+    const today = dayjs(e).format("YYYY/MM/DD");
+    setSelectedDate(findDailySleepData(today));
+  };
+
+  return (
+    <div>
+      <span>
+        Avg Sleep Quality for all Users:{" "}
+        {findAvg(sleepData, "sleepQuality").toFixed(1)}
+      </span>
+      <br />
+      <span>
+        Your Avg Sleep Quality / Hours Per Day:{" "}
+        {findAvg(userSleepData, "sleepQuality").toFixed(1)} ⭐️'s /
+        {findAvg(userSleepData, "hoursSlept").toFixed(1)} hours
+      </span>
+      <DatePicker onChange={(e) => handleChange(e)} />
+      <p>{selectedDate}</p>
+      <div className="water-intake-font">
+        <span>This week's sleep: </span>
+      </div>
+      <div className="lower-water-wrapper">
+        <div className="days-of-the-wk-grid">
+          <div className="dow m">M</div>
+          <div className="dow tu">Tu</div>
+          <div className="dow w">W</div>
+          <div className="dow th">Th</div>
+          <div className="dow f">F</div>
+          <div className="dow sa">Sa</div>
+          <div className="dow su">Su</div>
+
+          <div className="h2o amt m">{daysOfWeek[0] || "-"}</div>
+          <div className="h2o amt tu">{daysOfWeek[1] || "-"}</div>
+          <div className="h2o amt w">{daysOfWeek[2] || "-"}</div>
+          <div className="h2o amt th">{daysOfWeek[3] || "-"}</div>
+          <div className="h2o amt f">{daysOfWeek[4] || "-"}</div>
+          <div className="h2o amt sa">{daysOfWeek[5] || "-"}</div>
+          <div className="h2o amt su">{daysOfWeek[6] || "-"}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Sleep;

--- a/src/pages/_stepGoals.js
+++ b/src/pages/_stepGoals.js
@@ -1,50 +1,32 @@
 import React from "react";
 import { useSelector } from "react-redux";
+import { findAvg } from "../../utils/helpers.utils";
 
 const StepGoals = () => {
   const user = useSelector((state) => state.user);
   const users = useSelector((state) => state.users);
+  const firstName = user.name?.split(" ")[0];
 
-
-  const findUserFirstName = user.name?.split(" ")[0];
-
-  const findAvgSteps = () => {
-    const totalStepGoal = users.reduce((acc, user) => {
-      acc = acc += user.dailyStepGoal;
-
-      return acc;
-    }, 0);
-    return (totalStepGoal / users.length).toString()
-  };
   return (
- 
-      <div className="step-card">
-        <div className="step-header-wrapper">
-      <h2>Steps!</h2>
+    <div className="step-card">
+      <div className="step-header-wrapper">
+        <h2>Steps!</h2>
       </div>
       <section className="lower-step-card-container">
         <div className="step-avg-goal-wrapper">
-      <span>
-        {findUserFirstName}'s avg step goal: 
-      </span>
-      </div>
-      <div className="step-avg-goal-wrapper">
-      <span>
-        {user.dailyStepGoal}
-        </span>
+          <span>{firstName}'s avg step goal:</span>
         </div>
-      <div className="step-avg-goal-wrapper">
-      <span>Avg of all user's step goal: 
-        </span>
+        <div className="step-avg-goal-wrapper">
+          <span>{user.dailyStepGoal}</span>
         </div>
-         <div className="step-avg-goal-wrapper">
-       <span>
-        {findAvgSteps()}
-        </span>
-      </div>
+        <div className="step-avg-goal-wrapper">
+          <span>Avg of all user's step goal:</span>
+        </div>
+        <div className="step-avg-goal-wrapper">
+          <span>{findAvg(users, "dailyStepGoal").toString()}</span>
+        </div>
       </section>
-      </div>
-  
+    </div>
   );
 };
 

--- a/src/pages/_userDashboard.js
+++ b/src/pages/_userDashboard.js
@@ -5,6 +5,7 @@ import Diversity3OutlinedIcon from "@mui/icons-material/Diversity3Outlined";
 import StepGoals from "./_stepGoals";
 import Hydration from "./_hydration";
 import WaterDroplet from "@/_waterDroplet";
+import Sleep from "./_sleep";
 
 const UserDashboard = () => {
   const user = useSelector((state) => state.user);
@@ -27,6 +28,7 @@ const UserDashboard = () => {
       <div className="widget-container">
       <StepGoals />
       <Hydration />
+      <Sleep/>
       {/* <WaterDroplet/> */}
       </div>
       </div>

--- a/utils/helpers.utils.js
+++ b/utils/helpers.utils.js
@@ -28,6 +28,8 @@ export const getDaysOfWeek = () => {
     previousDaysOfWeek.push(formattedDate);
   }
   previousDaysOfWeek.push(dayjs().format("YYYY/MM/DD"));
+ 
+  
   return previousDaysOfWeek;
 };
 

--- a/utils/helpers.utils.js
+++ b/utils/helpers.utils.js
@@ -1,0 +1,40 @@
+import * as dayjs from "dayjs";
+
+export const getDaysOfWeek = () => {
+  const today = new Date();
+  const daysOfWeek = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+  const dayOfWeekIndex = today.getDay();
+  const mondayDate = new Date(today);
+  mondayDate.setDate(today.getDate() - dayOfWeekIndex + 1); // Set date to the nearest Monday
+  const previousDaysOfWeek = [];
+  for (let i = 1; i < dayOfWeekIndex; i++) {
+    const previousDay = new Date(mondayDate);
+    previousDay.setDate(mondayDate.getDate() + i - 1);
+    const formattedDate =
+      previousDay.getFullYear() +
+      "/" +
+      (previousDay.getMonth() + 1).toString().padStart(2, "0") +
+      "/" +
+      previousDay.getDate().toString().padStart(2, "0");
+
+    previousDaysOfWeek.push(formattedDate);
+  }
+  previousDaysOfWeek.push(dayjs().format("YYYY/MM/DD"));
+  return previousDaysOfWeek;
+};
+
+export const findAvg = (array, key) => {
+  const avg = array.reduce((acc, cur) => {
+    acc += cur[key];
+    return acc;
+  }, 0);
+  return avg / array.length;
+};


### PR DESCRIPTION
Render:
- the average number of hours slept per day
- average sleep quality per day overall time
- hours a user has slept for a specific day (identified by a date)
- sleep quality for a specific day (identified by a date)
- how many hours a user slept each day over the course of a given week
- their sleep quality each day over the course of a given week
- the average sleep quality for all users

Refactor:
`getPreviousDaysOfWeek` function is now named`getDaysOfWeek` which returns today + previous days
![Screen Shot 2023-03-29 at 8 43 35 PM](https://user-images.githubusercontent.com/102757890/228714684-279b226b-7126-4b0b-9eaf-a8158e144ca7.png)

`findAvg` function is now dynamic, it takes in the array and key you want to find average data for.
![Screen Shot 2023-03-29 at 8 44 57 PM](https://user-images.githubusercontent.com/102757890/228714859-3fa50777-6072-4f53-b227-6a5ce3df93af.png)

Both functions have been exported and now live in `helpers.utils.js` and are used throughout multiple widgets

Also created two variables that map over an array of days abbreviated and return the grid elements needed. This eliminates 20+ lines of code between `hydration` and `sleep`. Depending on how we want to handle classnames, these variables could be exported into the `helper` file since they're being used in multiple places.
![Screen Shot 2023-03-30 at 12 21 49 PM](https://user-images.githubusercontent.com/102757890/228930603-be0bef99-b762-4b14-9f68-081dc48fb7b8.png)
![Screen Shot 2023-03-30 at 12 22 54 PM](https://user-images.githubusercontent.com/102757890/228930692-d11e9afd-74d0-41ee-870a-dc884c505803.png)
![Screen Shot 2023-03-30 at 12 22 25 PM](https://user-images.githubusercontent.com/102757890/228930720-419ea2e3-e5cb-4482-8020-3e61f172e13a.png)



Styling is currently horrendous
![Screen Shot 2023-03-29 at 8 46 46 PM](https://user-images.githubusercontent.com/102757890/228715219-1c6072e0-41de-424a-8c2d-502f604ac896.png)

 